### PR TITLE
adding event topic which were observed from other cameras

### DIFF
--- a/src/onvif/SubscriberGroup.js
+++ b/src/onvif/SubscriberGroup.js
@@ -10,7 +10,9 @@ export const CALLBACK_TYPES = {
 };
 
 const EVENTS = {
-  'RuleEngine/CellMotionDetector/Motion': CALLBACK_TYPES.motion
+  'RuleEngine/CellMotionDetector/Motion': CALLBACK_TYPES.motion,
+  'RuleEngine/CellMotionDetector/Motion//.': CALLBACK_TYPES.motion,
+  'VideoSoure/MotionAlarm': CALLBACK_TYPES.motion
 };
 
 const DEFAULT_CALLBACKS = {
@@ -44,7 +46,7 @@ export default class SubscriberGroup {
 
   onSubscriberEvent = (subscriberName, event) => {
     const [namespace, eventType] = event.topic._.split(NAMESPACE_DELIMITER);
-    
+
     const callbackType = EVENTS[eventType];
     const eventValue = event.message.message.data.simpleItem.$.Value;
 


### PR DESCRIPTION
Since the event matching is based on keys in an object it requires a precise match.  This adds topics from other cameras that correspond to motion events